### PR TITLE
eval backwards compatibility fix

### DIFF
--- a/adsorbml/scripts/dense_eval.py
+++ b/adsorbml/scripts/dense_eval.py
@@ -196,12 +196,6 @@ def filter_ml_data(ml_data, dft_data):
     constraint checks, set energies to an arbitrarily high value to ensure
     a failure case in evaluation.
     """
-    new_ml_data = defaultdict(dict)
-    for system in ml_data:
-        for config in ml_data[system]:
-            new_ml_data[system][config] = ml_data[system][config]
-
-    ml_data = new_ml_data
     # set missing systems to high energy
     # set missing systems to 0 DFT compute
     for system in dft_data:

--- a/adsorbml/scripts/dense_eval.py
+++ b/adsorbml/scripts/dense_eval.py
@@ -199,16 +199,7 @@ def filter_ml_data(ml_data, dft_data):
     new_ml_data = defaultdict(dict)
     for system in ml_data:
         for config in ml_data[system]:
-            ### backwards compatibility for old dataset versions
-            if "randpl" in config or "adslab" in config:
-                if "randpl" in config:
-                    newconfig = "rand" + config.split("randpl")[1]
-                    new_ml_data[system][newconfig] = ml_data[system][config]
-                else:
-                    newconfig = "heur" + config.split("adslab")[1]
-                    new_ml_data[system][newconfig] = ml_data[system][config]
-            else:
-                new_ml_data[system][config] = ml_data[system][config]
+            new_ml_data[system][config] = ml_data[system][config]
 
     ml_data = new_ml_data
     # set missing systems to high energy

--- a/adsorbml/scripts/dense_eval.py
+++ b/adsorbml/scripts/dense_eval.py
@@ -199,12 +199,16 @@ def filter_ml_data(ml_data, dft_data):
     new_ml_data = defaultdict(dict)
     for system in ml_data:
         for config in ml_data[system]:
-            if "rand" in config:
-                newconfig = "rand" + config.split("randpl")[1]
-                new_ml_data[system][newconfig] = ml_data[system][config]
+            ### backwards compatibility for old dataset versions
+            if "randpl" in config or "adslab" in config:
+                if "randpl" in config:
+                    newconfig = "rand" + config.split("randpl")[1]
+                    new_ml_data[system][newconfig] = ml_data[system][config]
+                else:
+                    newconfig = "heur" + config.split("adslab")[1]
+                    new_ml_data[system][newconfig] = ml_data[system][config]
             else:
-                newconfig = "heur" + config.split("adslab")[1]
-                new_ml_data[system][newconfig] = ml_data[system][config]
+                new_ml_data[system][config] = ml_data[system][config]
 
     ml_data = new_ml_data
     # set missing systems to high energy


### PR DESCRIPTION
Evaluation code assumes that configs were saved with the old naming structure (`randpl`/`adslab`). Updates to only handle the publicly released dataset.