### PR TITLE
Minor fixes: min_diff abs ordering, fmax on only moveable atoms

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ b07c64158e4bfa5f7b9bf6263753ecc5  oc20dense_ref_energies.pkl
 
 ### Running `AdsorbML`
 
-Please see the [README](scripts/README.md) inside the `scripts` directory for instructions.
+Please see the [README](adsorbml/scripts/README.md) inside the `scripts` directory for instructions.
 
 ### Citing `AdsorbML`
 

--- a/adsorbml/scripts/README.md
+++ b/adsorbml/scripts/README.md
@@ -1,8 +1,7 @@
 
 ## How to run AdsorbML
 
-**Step 0**: Setup
-LMDBs, trajectories, and metadata files should be downloaded.
+**Step 0**: Setup: LMDBs, trajectories, and metadata files should be downloaded.
 
 **Step 1**: Run ML relaxations on the LMDB to generate predictions of relaxed energy and relaxed structures.
 For example, see [these instructions](https://github.com/Open-Catalyst-Project/ocp/blob/main/TRAIN.md#initial-structure-to-relaxed-structure-is2rs). We will be using the trajectory files.

--- a/adsorbml/scripts/process_mlrs.py
+++ b/adsorbml/scripts/process_mlrs.py
@@ -85,8 +85,9 @@ def process_mlrs(arg):
             for atoms in traj:
                 forces = atoms.get_forces()
                 tags = atoms.get_tags()
-                moveable_atoms = [idx for idx, tag in enumerate(tags) if tag != 0]
-                _fmax = max(np.sqrt((forces[moveable_atoms]**2).sum(axis=1)))
+                # only evaluate fmax on free atoms
+                free_atoms = [idx for idx, tag in enumerate(tags) if tag != 0]
+                _fmax = max(np.sqrt((forces[free_atoms] ** 2).sum(axis=1)))
                 if _fmax <= fmax:
                     final_atoms = atoms
                     break

--- a/adsorbml/scripts/process_mlrs.py
+++ b/adsorbml/scripts/process_mlrs.py
@@ -84,7 +84,9 @@ def process_mlrs(arg):
         if fmax:
             for atoms in traj:
                 forces = atoms.get_forces()
-                _fmax = max(np.sqrt((forces**2).sum(axis=1)))
+                tags = atoms.get_tags()
+                moveable_atoms = [idx for idx, tag in enumerate(tags) if tag != 0]
+                _fmax = max(np.sqrt((forces[moveable_atoms]**2).sum(axis=1)))
                 if _fmax <= fmax:
                     final_atoms = atoms
                     break
@@ -107,11 +109,11 @@ def process_mlrs(arg):
     # Verify adslab and slab are ordered consistently before anomaly detection
     # This checks that the positions of the initial adslab and clean surface
     # are approximately equivalent.
-    diff = (min_diff(init_atoms[tags != 2], slab_traj[0])).sum()
+    diff = abs(min_diff(init_atoms[tags != 2], slab_traj[0])).sum()
     # ML trajectories are saved out after 1 optimization step, so some movement
     # is expected. A cushion of 0.5A is used based off the maximum difference
     # previously measured for sample trajectories.
-    assert abs(diff) < 0.5
+    assert diff < 0.5
 
     detector = DetectTrajAnomaly(
         init_atoms,


### PR DESCRIPTION
1. Absolute value on `min_diff` should be done before `sum`, not after. This does not change any results for OC20-dense because this is only for verification, and the surfaces all match.
2. fmax check should only consider forces on moveable atoms. This also does not change any results for OC20-dense because forces are zero on the fixed atoms, and this change is just meant for verification in case it is used on other datasets or inference code.
3. Minor readme fixes